### PR TITLE
Quadratic encoding in SOS

### DIFF
--- a/StochasticBarrierFunctions/src/Data/Data.jl
+++ b/StochasticBarrierFunctions/src/Data/Data.jl
@@ -1,5 +1,7 @@
 module Data
 
+using StochasticBarrierFunctions, LazySets
+
 # Helper functions for loading data
 using YAXArrays, YAXArrayBase, DimensionalData
 using MAT.MAT_v4, MAT.MAT_v5, MAT.MAT_HDF5

--- a/StochasticBarrierFunctions/src/Data/Data.jl
+++ b/StochasticBarrierFunctions/src/Data/Data.jl
@@ -1,6 +1,7 @@
 module Data
 
-using StochasticBarrierFunctions, LazySets
+using StochasticBarrierFunctions
+using LazySets, SparseArrays
 
 # Helper functions for loading data
 using YAXArrays, YAXArrayBase, DimensionalData

--- a/StochasticBarrierFunctions/src/Plots/Plots.jl
+++ b/StochasticBarrierFunctions/src/Plots/Plots.jl
@@ -1,5 +1,7 @@
 module Plots 
 
+using StochasticBarrierFunctions, LazySets
+
 using Plots
 
 export plot_environment, plot_3d_barrier

--- a/StochasticBarrierFunctions/src/StochasticBarrierFunctions.jl
+++ b/StochasticBarrierFunctions/src/StochasticBarrierFunctions.jl
@@ -29,6 +29,7 @@ export AdditiveGaussianLinearSystem, AdditiveGaussianUncertainPWASystem, Uncerta
 export dynamics, noise_distribution, dimensionality
 
 include("region.jl")
+export RegionWithProbabilities
 export region, prob_lower, prob_upper, prob_unsafe_lower, prob_unsafe_upper
 
 include("probabilities.jl")


### PR DESCRIPTION
This was a bit of an experiment, but it turns out to be pretty useful. When encoding regions, this uses a quadratic encoding of (possibly unbounded) H-polyhedra from (M. Johansson and A. Rantzer, "Computation of piecewise quadratic Lyapunov functions for hybrid systems," 1998, 10.1109/9.664157.) rather than the (trivial) quadratic encoding of hyperrectangles. Turns out, you get the exact same result for hyperrectangles, but it is more general (by encoding all H-poly, including unbounded). 

From my derivations, a quadratic encoding will be crucial in synthesizing PWQ/PW SoS barriers - if not using a quadratic encoding, all barriers will be trivial.